### PR TITLE
This adds automated build tests

### DIFF
--- a/.github/workflows/pytest-cpu.yml
+++ b/.github/workflows/pytest-cpu.yml
@@ -49,5 +49,6 @@ jobs:
         run: |
           export WITH_CUDA=False
           pip install python/
-      - name: Test with pytest
-        run: pytest python/tests
+      # TODO activate pytests when ready
+      # - name: Test with pytest
+      #   run: pytest python/tests

--- a/.github/workflows/pytest-cpu.yml
+++ b/.github/workflows/pytest-cpu.yml
@@ -1,6 +1,6 @@
 # Runs all the Python SDK tests within the `tests/` directory to check our code
 
-name: CI Tests
+name: CI Tests with CPU build
 permissions: read-all
 
 on:
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pytest:
+  pytest-cpu:
     name: pytest (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/pytest-cpu.yml
+++ b/.github/workflows/pytest-cpu.yml
@@ -1,0 +1,53 @@
+# Runs all the Python SDK tests within the `tests/` directory to check our code
+
+name: CI Tests
+permissions: read-all
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - dev
+
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.8", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          environment-file: environment-cpu.yml
+          activate-environment: cnine
+      - name: Install Missing Developper packages
+        run: conda install pytest
+      - name: Install and build
+        run: |
+          export WITH_CUDA=False
+          pip install python/
+      - name: Test with pytest
+        run: pytest python/tests

--- a/.github/workflows/pytest-cpu.yml
+++ b/.github/workflows/pytest-cpu.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.8", "3.12"]
     steps:
       - name: Checkout

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -1,0 +1,56 @@
+# Runs all the Python SDK tests within the `tests/` directory to check our code
+
+name: CI Tests
+permissions: read-all
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.11"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          environment-file: environment-gpu.yml
+          activate-environment: cnine
+      - name: Install Missing Developper packages
+        # We use pip here, since conda isn't very happy with the total env, but it works...
+        run: pip install pytest
+      - name: Install and build
+        run: |
+          export WITH_CUDA=True
+          export CUDA_HOME=$CONDA_PREFIX
+          # Pretending we have a CUDA capable card on the runner
+          export TORCH_CUDA_ARCH_LIST="7.5"
+          pip install python/
+      - name: Test with pytest
+        run: pytest python/tests

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -52,5 +52,6 @@ jobs:
           # Pretending we have a CUDA capable card on the runner
           export TORCH_CUDA_ARCH_LIST="7.5"
           pip install python/
-      - name: Test with pytest
-        run: pytest python/tests
+      # TODO activate pytests when ready
+      # - name: Test with pytest
+      #   run: pytest python/tests

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -31,8 +31,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.11"]
+        os: ["ubuntu-latest", "windows-latest"]
+        python-version: ["3.8", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest"]
         python-version: ["3.8", "3.12"]
     steps:
       - name: Checkout

--- a/.github/workflows/pytest-gpu.yml
+++ b/.github/workflows/pytest-gpu.yml
@@ -1,6 +1,6 @@
 # Runs all the Python SDK tests within the `tests/` directory to check our code
 
-name: CI Tests
+name: CI Tests with GPU/CUDA build
 permissions: read-all
 
 on:
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pytest:
+  pytest-gpu:
     name: pytest (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ python/cnine
 *.so
 
 .vscode
+
+cnine.log

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -1,0 +1,7 @@
+name: cnine
+channels:
+  - pytorch
+  - defaults
+dependencies:
+  - pytorch
+

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -1,0 +1,9 @@
+name: cnine
+channels:
+  - pytorch
+  - nvidia
+  - defaults
+dependencies:
+  - pytorch
+  - cuda-toolkit
+  - pytorch-cuda

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -5,5 +5,8 @@ channels:
   - defaults
 dependencies:
   - pytorch
+  # So this setup works, somewhat
+  #  - it installs $CUDA_HOME into $CONDA_PREFIX (run: export CUDA_HOME=$CONDA_PREFIX) before
+  #  - something is unhappy after, which prevents packages from being added. But it compiles.
   - cuda-toolkit
   - pytorch-cuda

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,20 +1,20 @@
 import sys,os
-import torch 
+import torch
 from setuptools import setup
 from setuptools import find_packages
 from torch.utils.cpp_extension import CppExtension, BuildExtension, CUDAExtension
-import time 
+import time
 from glob import glob
 
 def main():
-    
+
  # --- User settings ------------------------------------------------------------------------------------------
 
 
- compile_with_cuda=False
+ compile_with_cuda=os.environ("WITH_CUDA", False)
 
- copy_warnings=False
- torch_convert_warnings=False
+ copy_warnings=os.environ("COPY_WARNING", False)
+ torch_convert_warnings=os.environ("TORCH_CONVERT_WARNINGS", False)
 
 
  # ------------------------------------------------------------------------------------------------------------
@@ -116,7 +116,7 @@ def main():
                                     'nvcc': _nvcc_compile_args,
                                     'cxx': _cxx_compile_args},
                                 depends=_depends,
-                                )] 
+                                )]
  else:
      ext_modules=[CppExtension('cnine_base',
                                ['bindings/cnine_py.cpp'],
@@ -144,7 +144,7 @@ if __name__ == "__main__":
 print("Compilation finished:",time.ctime(time.time()))
 
 
-#os.environ['CUDA_HOME']='/usr/local/cuda' #doesn't work, need explicit export 
+#os.environ['CUDA_HOME']='/usr/local/cuda' #doesn't work, need explicit export
 #os.environ["CC"] = "clang"
 #CUDA_HOME='/usr/local/cuda'
 #print(torch.cuda.is_available())

--- a/python/setup.py
+++ b/python/setup.py
@@ -57,18 +57,21 @@ def main():
      ]
 
  _cxx_compile_args=['-std=c++17',
-                    '-Wno-sign-compare',
-                    '-Wno-deprecated-declarations',
-                    '-Wno-unused-variable',
-                    '-Wno-unused-but-set-variable',
-                    '-Wno-reorder',
-                    '-Wno-reorder-ctor',
                     '-D_WITH_ATEN',
                     '-DCNINE_RANGE_CHECKING',
                     '-DCNINE_SIZE_CHECKING',
                     '-DCNINE_DEVICE_CHECKING',
                     '-DWITH_FAKE_GRAD'
                    ]
+# Adding compiler spcific flags
+if os.name == "posix":
+ _cxx_compile_args += ['-Wno-sign-compare',
+                       '-Wno-deprecated-declarations',
+                       '-Wno-unused-variable',
+                       '-Wno-unused-but-set-variable',
+                       '-Wno-reorder',
+                       '-Wno-reorder-ctor',
+                       ]
 
  if copy_warnings:
      _cxx_compile_args.extend([

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,10 +11,10 @@ def main():
  # --- User settings ------------------------------------------------------------------------------------------
 
 
- compile_with_cuda=os.environ("WITH_CUDA", False)
+ compile_with_cuda=os.environ.get("WITH_CUDA", False)
 
- copy_warnings=os.environ("COPY_WARNING", False)
- torch_convert_warnings=os.environ("TORCH_CONVERT_WARNINGS", False)
+ copy_warnings=os.environ.get("COPY_WARNING", False)
+ torch_convert_warnings=os.environ.get("TORCH_CONVERT_WARNINGS", False)
 
 
  # ------------------------------------------------------------------------------------------------------------

--- a/python/setup.py
+++ b/python/setup.py
@@ -63,15 +63,15 @@ def main():
                     '-DCNINE_DEVICE_CHECKING',
                     '-DWITH_FAKE_GRAD'
                    ]
-# Adding compiler spcific flags
-if os.name == "posix":
- _cxx_compile_args += ['-Wno-sign-compare',
-                       '-Wno-deprecated-declarations',
-                       '-Wno-unused-variable',
-                       '-Wno-unused-but-set-variable',
-                       '-Wno-reorder',
-                       '-Wno-reorder-ctor',
-                       ]
+ # Adding compiler spcific flags
+ if os.name == "posix":
+  _cxx_compile_args += ['-Wno-sign-compare',
+                        '-Wno-deprecated-declarations',
+                        '-Wno-unused-variable',
+                        '-Wno-unused-but-set-variable',
+                        '-Wno-reorder',
+                        '-Wno-reorder-ctor',
+                        ]
 
  if copy_warnings:
      _cxx_compile_args.extend([


### PR DESCRIPTION
This checks if the current version of cnine can be build with conda managing the dependencies.

I needed to build off-of `main` instead of `dev` since the `dev` branch is failing to build at the moment.

It is setup to run the tests automatically for any PR that targets `main` or `dev` and any pushed changes directly on `main`.
This is usually a good setup to make sure, we can always ship a working version.
It also displays on the README if the code failed or passes the last build test.

We have passing builds for CPU on Mac and Linux (Ubuntu) and GPU/CUDA builds on Linux only (no  CUDA for mac on conda.)
I am testing 2 python versions, one as minimum requirement and a fairly new one.

I wasn't able to get this to work on Windows.
I am reasonably sure that Windows isn't our main target user base, but we can put some more effort in to make it windows accessible.
(On my last paper that included a code review, the reviewer demanded a working windows version.)

The badges in the README will only work after merging.